### PR TITLE
OSGi requirements on (osgi.extender=osgi.ds) should be migrated to (osgi.extender=osgi.component) in R5 indexer

### DIFF
--- a/bindex-maven-plugin/pom.xml
+++ b/bindex-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>at.bestsolution</groupId>
 	<artifactId>bindex-maven-plugin</artifactId>
-	<version>1.0.0</version>
+	<version>3.0.0</version>
 	<packaging>maven-plugin</packaging>
 
 	<name>bindex2 maven plugin</name>
@@ -121,7 +121,7 @@
 		<dependency>
 			<groupId>biz.aQute.bnd</groupId>
 			<artifactId>org.osgi.impl.bundle.repoindex.cli</artifactId>
-			<version>2.1.5</version>
+			<version>3.0.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
possible fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=484549

updated biz.aQute.bnd:org.osgi.impl.bundle.repoindex.cli dependency to 3.0.0
also updated plugin version to reflect wrapped cli version
